### PR TITLE
add API prefix

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -3,6 +3,7 @@ var express = require('express');
 var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
+const prefixRouter = express.Router();
 
 var indexRouter = require('./routes/index');
 var eventsRouter = require('./routes/events');
@@ -27,8 +28,8 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use('/', indexRouter);
-app.use('/events', eventsRouter);
+prefixRouter.use('/events', eventsRouter);
+app.use('/api/v1', prefixRouter);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {


### PR DESCRIPTION
**Highlights**
- Adds the api prefix`/api/v1` to all routes on the backend. This is so requests for pages on the frontend won't interfere with API requests on the backend, which both used the same route style.